### PR TITLE
use ServiceCatalogAPIServer custom resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,50 +1,63 @@
 # cluster-svcat-apiserver-operator
-The openshift-svcat-apiserver-operator installs and maintains openshift/service-catalog on a cluster
+The cluster-svcat-apiserver-operator installs and maintains openshift/service-catalog on a cluster.  This operator only deals with the API Server portion of Service Catalog; see also the `cluster-svcat-controller-manager-operator`.
 
+Note that the manifests do not create the Cluster Operator or the ServiceCatalogAPIServer custom resource.  While the CVO installs the Service Catalog operators, we don't want Service Catalog installed by default.  The cluster admin must create the ServiceCatalogAPIServer CR to cause the operator to perform the installation ([see below](#Trigger-installation-of-Service-Catalog-API-Server))
 
-## for immediate use
-1. Use openshift/installer to install a cluster
-2. The following install you will be using the latest svcat-apiserver operator pushed to jboyd01 docker repo - official builds & repo are not setup yet.
-3. oc apply the following:
-```
- oc apply -f manifests/0000_61_openshift-apiserver-operator_00_namespace.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_03_configmap.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_04_roles.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_05_serviceaccount.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_06_service.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_07_clusteroperator.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_08_deployment.yaml
-```
+Once the operator detects the CR it will create the Service Catalog Cluster Operator resource and proceed with reconciling the Service Catalog API Server deployment.
 
-Watch for service catalog apiservers to come up in the kube-service-catalog namespace.
-
-verification:
-```
-oc get clusteroperators openshift-svcat-apiserver
-NAME                        VERSION   AVAILABLE   PROGRESSING   FAILING   SINCE
-openshift-svcat-apiserver             True        False         False     10m
-```
-Review operator deployment events, ensure its not looping:
-```
-oc describe deployment openshift-svcat-apiserver-operator -n openshift-svcat-apiserver-operator
-```
-
-
-## Recommended development flow
-1. Use openshift/installer to install a cluster
+## Deployment the operator prior to CVO integration
+1. Use openshift/installer to install a cluster.  Skip to step 6 if you want to use pre-built operator images.
 2. `make images`
 3. `docker tag openshift/origin-cluster-svcat-apiserver-operator:latest <yourdockerhubid>/origin-cluster-svcat-apiserver-operator:latest`
 4. `docker push <yourdockerhubid>/origin-cluster-svcat-apiserver-operator:latest`
-5. edit manifests/0000_61_openshift-apiserver-operator_07_deployment.yaml update the containers/image to `<yourdockerhubid>/origin-cluster-svcat-apiserver-operator:latest` and update the pull policy to `Always`
-6.  oc apply the following:
+5. edit manifests/0000_61_openshift-svcat-apiserver-operator_08_deployment.yaml and update the containers/image to `<yourdockerhubid>/origin-cluster-svcat-apiserver-operator:latest` and set the pull policy to `Always`
+6.  `oc apply -f manifests`
+
+This will cause the creation of the cluster-svcat-apiserver-operator deployment 
+and associated resources.  The operator waits for creation of the `ServiceCatalogAPIServer`
+custom resource before doing any real work including creating the Cluster Operator `openshift-svcat-apiserver`.  
+
+## Trigger installation of Service Catalog API Server
+Create the `ServiceCatalogAPIServer` CR to trigger the installation of Service Catalog:
 ```
- oc apply -f manifests/0000_61_openshift-apiserver-operator_00_namespace.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_03_configmap.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_04_roles.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_05_serviceaccount.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_06_service.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_07_clusteroperator.yaml
- oc apply -f manifests/0000_61_openshift-apiserver-operator_08_deployment.yaml
+$ cat <<'EOF' | oc create -f -
+apiVersion: operator.openshift.io/v1
+kind: ServiceCatalogAPIServer
+metadata:
+  name: cluster
+spec:
+  managementState: Managed
+EOF
 ```
+Once the cluster `ServiceCatalogAPIServer` is found to exist and have a `managementState` of `Managed` the operator will create necessary resources in the
+`kube-service-catalog` namespace for deploying the Service Catalog API Server.
+
+Watch for service catalog apiservers to come up in the kube-service-catalog namespace.
+
+## Verification & debugging
+Nothing happens without the CR:
+```
+$ oc get servicecatalogapiservers
+NAME      AGE
+cluster     10m
+```
+If the state is `Managed` the operator will install Service Catalog API Server.  You can remove the deployment by setting the state to `Removed`.  
+
+Once the CR is created the operator should create a new ClusterOperator resource:
+```
+oc get clusteroperator openshift-svcat-apiserver
+NAME                        VERSION   AVAILABLE   PROGRESSING   FAILING   SINCE
+openshift-svcat-apiserver             True        False         False     1m
+```
+Review operator pod logs from the `openshift-svcat-apiserver` namespace to see details of the operator processing.
+
+
+The operator deployment events will give you an overview of what it's done.  Ensure its not looping & review the events:
+```
+$ oc describe deployment openshift-svcat-apiserver-operator -n openshift-svcat-apiserver-operator
+```
+
+
+
 
 

--- a/bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
@@ -36,8 +36,6 @@ spec:
         - "/var/run/secrets/etcd-client/tls.crt"
         - --etcd-keyfile
         - "/var/run/secrets/etcd-client/tls.key"
-        - -v
-        - "9"
         - --cors-allowed-origins
         - "localhost"
         - --enable-admission-plugins

--- a/bindata/v3.11.0/openshift-svcat-apiserver/operator-config.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/operator-config.yaml
@@ -1,14 +1,9 @@
 apiVersion: operator.openshift.io/v1
 kind: OpenShiftAPIServer
 metadata:
-  name: svcat
+  name: cluster
 spec:
   logLevel: "Normal"
   managementState: Managed
-  observedConfig:
-    imagePolicyConfig:
-      internalRegistryHostname: image-registry.openshift-image-registry.svc:5000
-    routingConfig:
-      subdomain: apps.jaboyd-0208.devcluster.openshift.com
   operandSpecs: null
   unsupportedConfigOverrides: null

--- a/manifests/0000_61_openshift-svcat-apiserver-operator_02_config.crd.yaml
+++ b/manifests/0000_61_openshift-svcat-apiserver-operator_02_config.crd.yaml
@@ -1,0 +1,16 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: servicecatalogapiservers.operator.openshift.io
+spec:
+  scope: Cluster
+  group: operator.openshift.io
+  version: v1
+  names:
+    kind: ServiceCatalogAPIServer
+    plural: servicecatalogapiservers
+    singular: servicecatalogapiserver
+    categories:
+    - coreoperators
+  subresources:
+    status: {}

--- a/manifests/0000_61_openshift-svcat-apiserver-operator_08_clusteroperator.yaml
+++ b/manifests/0000_61_openshift-svcat-apiserver-operator_08_clusteroperator.yaml
@@ -1,5 +1,0 @@
-apiVersion: config.openshift.io/v1
-kind: ClusterOperator
-metadata:
-  name: openshift-svcat-apiserver
-spec: {}

--- a/manifests/0000_61_openshift-svcat-apiserver-operator_08_deployment.yaml
+++ b/manifests/0000_61_openshift-svcat-apiserver-operator_08_deployment.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  namespace: openshift-svcat-apiserver-operator
+  name: openshift-svcat-apiserver-operator
+  labels:
+    app: openshift-svcat-apiserver-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: openshift-svcat-apiserver-operator
+  template:
+    metadata:
+      name: openshift-svcat-apiserver-operator
+      labels:
+        app: openshift-svcat-apiserver-operator
+    spec:
+      serviceAccountName: openshift-svcat-apiserver-operator
+      containers:
+      - name: operator
+        image: docker.io/jboyd01/origin-cluster-svcat-apiserver-operator:xx
+        imagePullPolicy: Always
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        command: ["cluster-svcat-apiserver-operator", "operator"]
+        args:
+        - "--config=/var/run/configmaps/config/config.yaml"
+        - "-v=5"
+        resources:
+          requests:
+            memory: 50Mi
+        volumeMounts:
+        - mountPath: /var/run/configmaps/config
+          name: config
+        - mountPath: /var/run/secrets/serving-cert
+          name: serving-cert
+        env:
+        - name: IMAGE
+          value: quay.io/openshift/origin-service-catalog:v4.0
+      volumes:
+      - name: serving-cert
+        secret:
+          secretName: openshift-svcat-apiserver-operator-serving-cert
+          optional: true
+      - name: config
+        configMap:
+          name: openshift-svcat-apiserver-operator-config
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - operator: Exists

--- a/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
+++ b/pkg/operator/configobservation/configobservercontroller/observe_config_controller.go
@@ -35,14 +35,16 @@ func NewConfigObserver(
 				ResourceSync:    resourceSyncer,
 				EndpointsLister: kubeInformersForEtcdNamespace.Core().V1().Endpoints().Lister(),
 				PreRunCachesSynced: []cache.InformerSynced{
-					operatorConfigInformers.Operator().V1().OpenShiftAPIServers().Informer().HasSynced,
+					operatorConfigInformers.Operator().V1().ServiceCatalogAPIServers().Informer().HasSynced,
 					kubeInformersForEtcdNamespace.Core().V1().Endpoints().Informer().HasSynced,
 				},
 			},
 		),
 	}
-	operatorConfigInformers.Operator().V1().OpenShiftAPIServers().Informer().AddEventHandler(c.EventHandler())
+	operatorConfigInformers.Operator().V1().ServiceCatalogAPIServers().Informer().AddEventHandler(c.EventHandler())
 	kubeInformersForEtcdNamespace.Core().V1().Endpoints().Informer().AddEventHandler(c.EventHandler())
-	configInformers.Config().V1().Images().Informer().AddEventHandler(c.EventHandler())
+
+	//TODO delete
+	//configInformers.Config().V1().Images().Informer().AddEventHandler(c.EventHandler())
 	return c
 }

--- a/pkg/operator/operatorclient/operatorclient.go
+++ b/pkg/operator/operatorclient/operatorclient.go
@@ -10,15 +10,15 @@ import (
 
 type OperatorClient struct {
 	Informers operatorv1informers.SharedInformerFactory
-	Client    operatorv1client.OpenShiftAPIServersGetter
+	Client    operatorv1client.ServiceCatalogAPIServersGetter
 }
 
 func (p *OperatorClient) Informer() cache.SharedIndexInformer {
-	return p.Informers.Operator().V1().OpenShiftAPIServers().Informer()
+	return p.Informers.Operator().V1().ServiceCatalogAPIServers().Informer()
 }
 
 func (c *OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operatorv1.OperatorStatus, string, error) {
-	instance, err := c.Informers.Operator().V1().OpenShiftAPIServers().Lister().Get("svcat")
+	instance, err := c.Informers.Operator().V1().ServiceCatalogAPIServers().Lister().Get("cluster")
 	if err != nil {
 		return nil, nil, "", err
 	}
@@ -27,7 +27,7 @@ func (c *OperatorClient) GetOperatorState() (*operatorv1.OperatorSpec, *operator
 }
 
 func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operatorv1.OperatorSpec) (*operatorv1.OperatorSpec, string, error) {
-	original, err := c.Informers.Operator().V1().OpenShiftAPIServers().Lister().Get("svcat")
+	original, err := c.Informers.Operator().V1().ServiceCatalogAPIServers().Lister().Get("cluster")
 	if err != nil {
 		return nil, "", err
 	}
@@ -35,7 +35,7 @@ func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operat
 	copy.ResourceVersion = resourceVersion
 	copy.Spec.OperatorSpec = *spec
 
-	ret, err := c.Client.OpenShiftAPIServers().Update(copy)
+	ret, err := c.Client.ServiceCatalogAPIServers().Update(copy)
 	if err != nil {
 		return nil, "", err
 	}
@@ -43,7 +43,7 @@ func (c *OperatorClient) UpdateOperatorSpec(resourceVersion string, spec *operat
 	return &ret.Spec.OperatorSpec, ret.ResourceVersion, nil
 }
 func (c *OperatorClient) UpdateOperatorStatus(resourceVersion string, status *operatorv1.OperatorStatus) (*operatorv1.OperatorStatus, error) {
-	original, err := c.Informers.Operator().V1().OpenShiftAPIServers().Lister().Get("svcat")
+	original, err := c.Informers.Operator().V1().ServiceCatalogAPIServers().Lister().Get("cluster")
 	if err != nil {
 		return nil, err
 	}
@@ -51,7 +51,7 @@ func (c *OperatorClient) UpdateOperatorStatus(resourceVersion string, status *op
 	copy.ResourceVersion = resourceVersion
 	copy.Status.OperatorStatus = *status
 
-	ret, err := c.Client.OpenShiftAPIServers().UpdateStatus(copy)
+	ret, err := c.Client.ServiceCatalogAPIServers().UpdateStatus(copy)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -558,8 +558,6 @@ spec:
         - "/var/run/secrets/etcd-client/tls.crt"
         - --etcd-keyfile
         - "/var/run/secrets/etcd-client/tls.key"
-        - -v
-        - "9"
         - --cors-allowed-origins
         - "localhost"
         - --enable-admission-plugins
@@ -658,17 +656,13 @@ func v3110OpenshiftSvcatApiserverNsYaml() (*asset, error) {
 var _v3110OpenshiftSvcatApiserverOperatorConfigYaml = []byte(`apiVersion: operator.openshift.io/v1
 kind: OpenShiftAPIServer
 metadata:
-  name: svcat
+  name: cluster
 spec:
   logLevel: "Normal"
   managementState: Managed
-  observedConfig:
-    imagePolicyConfig:
-      internalRegistryHostname: image-registry.openshift-image-registry.svc:5000
-    routingConfig:
-      subdomain: apps.jaboyd-0208.devcluster.openshift.com
   operandSpecs: null
-  unsupportedConfigOverrides: null`)
+  unsupportedConfigOverrides: null
+`)
 
 func v3110OpenshiftSvcatApiserverOperatorConfigYamlBytes() ([]byte, error) {
 	return _v3110OpenshiftSvcatApiserverOperatorConfigYaml, nil

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
@@ -72,7 +72,7 @@ func TestProgressingCondition(t *testing.T) {
 			configGeneration:            100,
 			configObservedGeneration:    101,
 			expectedStatus:              operatorv1.ConditionTrue,
-			expectedMessage:             "openshiftapiserveroperatorconfigs/instance: observed generation is 101, desired generation is 100.",
+			expectedMessage:             "servicecatalogapiserveroperatorconfigs/instance: observed generation is 101, desired generation is 100.",
 		},
 		{
 			name:                        "ConfigObservedBehind",
@@ -81,7 +81,7 @@ func TestProgressingCondition(t *testing.T) {
 			configGeneration:            101,
 			configObservedGeneration:    100,
 			expectedStatus:              operatorv1.ConditionTrue,
-			expectedMessage:             "openshiftapiserveroperatorconfigs/instance: observed generation is 100, desired generation is 101.",
+			expectedMessage:             "servicecatalogapiserveroperatorconfigs/instance: observed generation is 100, desired generation is 101.",
 		},
 		{
 			name:                        "MultipleObservedAhead",
@@ -90,7 +90,7 @@ func TestProgressingCondition(t *testing.T) {
 			configGeneration:            100,
 			configObservedGeneration:    101,
 			expectedStatus:              operatorv1.ConditionTrue,
-			expectedMessage:             "daemonset/apiserver.openshift-operator: observed generation is 101, desired generation is 100.\nopenshiftapiserveroperatorconfigs/instance: observed generation is 101, desired generation is 100.",
+			expectedMessage:             "daemonset/apiserver.openshift-operator: observed generation is 101, desired generation is 100.\nservicecatalogapiserveroperatorconfigs/instance: observed generation is 101, desired generation is 100.",
 		},
 		{
 			name:                        "ConfigAndDaemonSetGenerationMismatch",
@@ -120,15 +120,15 @@ func TestProgressingCondition(t *testing.T) {
 					},
 				})
 
-			operatorConfig := &operatorv1.OpenShiftAPIServer{
+			operatorConfig := &operatorv1.ServiceCatalogAPIServer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       "svcat",
+					Name:       "cluster",
 					Generation: tc.configGeneration,
 				},
-				Spec: operatorv1.OpenShiftAPIServerSpec{
+				Spec: operatorv1.ServiceCatalogAPIServerSpec{
 					OperatorSpec: operatorv1.OperatorSpec{},
 				},
-				Status: operatorv1.OpenShiftAPIServerStatus{
+				Status: operatorv1.ServiceCatalogAPIServerStatus{
 					OperatorStatus: operatorv1.OperatorStatus{
 						ObservedGeneration: tc.configObservedGeneration,
 					},
@@ -138,7 +138,7 @@ func TestProgressingCondition(t *testing.T) {
 			openshiftConfigClient := configfake.NewSimpleClientset()
 			kubeAggregatorClient := kubeaggregatorfake.NewSimpleClientset()
 
-			operator := OpenShiftAPIServerOperator{
+			operator := ServiceCatalogAPIServerOperator{
 				kubeClient:              kubeClient,
 				eventRecorder:           events.NewInMemoryRecorder(""),
 				operatorConfigClient:    apiServiceOperatorClient.OperatorV1(),
@@ -146,9 +146,9 @@ func TestProgressingCondition(t *testing.T) {
 				apiregistrationv1Client: kubeAggregatorClient.ApiregistrationV1(),
 			}
 
-			syncOpenShiftAPIServer_v311_00_to_latest(operator, operatorConfig)
+			syncServiceCatalogAPIServer_v311_00_to_latest(operator, operatorConfig)
 
-			result, err := apiServiceOperatorClient.OperatorV1().OpenShiftAPIServers().Get("svcat", metav1.GetOptions{})
+			result, err := apiServiceOperatorClient.OperatorV1().ServiceCatalogAPIServers().Get("cluster", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -295,15 +295,15 @@ func TestAvailableStatus(t *testing.T) {
 					},
 				})
 
-			operatorConfig := &operatorv1.OpenShiftAPIServer{
+			operatorConfig := &operatorv1.ServiceCatalogAPIServer{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:       "svcat",
+					Name:       "cluster",
 					Generation: 99,
 				},
-				Spec: operatorv1.OpenShiftAPIServerSpec{
+				Spec: operatorv1.ServiceCatalogAPIServerSpec{
 					OperatorSpec: operatorv1.OperatorSpec{},
 				},
-				Status: operatorv1.OpenShiftAPIServerStatus{
+				Status: operatorv1.ServiceCatalogAPIServerStatus{
 					OperatorStatus: operatorv1.OperatorStatus{
 						ObservedGeneration: 99,
 					},
@@ -328,7 +328,7 @@ func TestAvailableStatus(t *testing.T) {
 				kubeAggregatorClient.PrependReactor("*", "apiservices", tc.apiServiceReactor)
 			}
 
-			operator := OpenShiftAPIServerOperator{
+			operator := ServiceCatalogAPIServerOperator{
 				kubeClient:              kubeClient,
 				eventRecorder:           events.NewInMemoryRecorder(""),
 				operatorConfigClient:    apiServiceOperatorClient.OperatorV1(),
@@ -336,9 +336,9 @@ func TestAvailableStatus(t *testing.T) {
 				apiregistrationv1Client: kubeAggregatorClient.ApiregistrationV1(),
 			}
 
-			syncOpenShiftAPIServer_v311_00_to_latest(operator, operatorConfig)
+			syncServiceCatalogAPIServer_v311_00_to_latest(operator, operatorConfig)
 
-			result, err := apiServiceOperatorClient.OperatorV1().OpenShiftAPIServers().Get("svcat", metav1.GetOptions{})
+			result, err := apiServiceOperatorClient.OperatorV1().ServiceCatalogAPIServers().Get("cluster", metav1.GetOptions{})
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
* Use the new ServiceCatalogAPIServer CRD & associated helpers from API & client-go
* Don't create ClusterOperator object until we have the cluster ServiceCatalogAPIServer CR
* General cleanup