### PR TITLE
Add missing apiGroup on servicecatalog-serviceclass-viewer-binding

### DIFF
--- a/bindata/v3.11.0/openshift-svcat-apiserver/crb-serviceclass-viewer-binding.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/crb-serviceclass-viewer-binding.yaml
@@ -3,8 +3,10 @@ kind: ClusterRoleBinding
 metadata:
   name: servicecatalog-serviceclass-viewer-binding
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: servicecatalog-serviceclass-viewer
 subjects:
-- kind: Group
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
   name: system:authenticated

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -477,10 +477,12 @@ kind: ClusterRoleBinding
 metadata:
   name: servicecatalog-serviceclass-viewer-binding
 roleRef:
+  apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole
   name: servicecatalog-serviceclass-viewer
 subjects:
-- kind: Group
+- apiGroup: rbac.authorization.k8s.io
+  kind: Group
   name: system:authenticated
 `)
 


### PR DESCRIPTION
prior to this fix this binding would be constantly reprocessed and changes applied.