### PR TITLE
remove operator-config & defaultconfig

### DIFF
--- a/bindata/v3.11.0/openshift-svcat-apiserver/defaultconfig.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/defaultconfig.yaml
@@ -1,4 +1,0 @@
-apiVersion: openshiftcontrolplane.config.openshift.io/v1
-kind: OpenShiftAPIServerConfig
-aggregatorConfig:
-

--- a/bindata/v3.11.0/openshift-svcat-apiserver/operator-config.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/operator-config.yaml
@@ -1,9 +1,0 @@
-apiVersion: operator.openshift.io/v1
-kind: OpenShiftAPIServer
-metadata:
-  name: cluster
-spec:
-  logLevel: "Normal"
-  managementState: Managed
-  operandSpecs: null
-  unsupportedConfigOverrides: null

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -9,11 +9,9 @@ import (
 
 	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/operator/resourcesynccontroller"
-	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/operator/v311_00_assets"
 	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/operator/workloadcontroller"
 
 	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned"
@@ -23,9 +21,7 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	apiregistrationclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	apiregistrationinformers "k8s.io/kube-aggregator/pkg/client/informers/externalversions"
@@ -44,20 +40,10 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	if err != nil {
 		return err
 	}
-	dynamicClient, err := dynamic.NewForConfig(ctx.KubeConfig)
-	if err != nil {
-		return err
-	}
 	configClient, err := configv1client.NewForConfig(ctx.KubeConfig)
 	if err != nil {
 		return err
 	}
-
-	v1helpers.EnsureOperatorConfigExists(
-		dynamicClient,
-		v311_00_assets.MustAsset("v3.11.0/openshift-svcat-apiserver/operator-config.yaml"),
-		schema.GroupVersionResource{Group: operatorv1.GroupName, Version: operatorv1.GroupVersion.Version, Resource: "openshiftapiservers"},
-	)
 
 	operatorConfigInformers := operatorv1informers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
 	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient,
@@ -113,8 +99,6 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 		"service-catalog-apiserver",
 		append(
 			[]configv1.ObjectReference{
-				//TODO: this should be a service catalog api server config map
-				{Group: "operator.openshift.io", Resource: "openshiftapiservers", Name: "svcat"},
 				{Resource: "namespaces", Name: operatorclient.UserSpecifiedGlobalConfigNamespace},
 				{Resource: "namespaces", Name: operatorclient.MachineSpecifiedGlobalConfigNamespace},
 				{Resource: "namespaces", Name: operatorclient.OperatorNamespace},

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -13,10 +13,8 @@
 // bindata/v3.11.0/openshift-svcat-apiserver/crb-readiness-binding.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/crb-sar-creator-binding.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/crb-serviceclass-viewer-binding.yaml
-// bindata/v3.11.0/openshift-svcat-apiserver/defaultconfig.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/ns.yaml
-// bindata/v3.11.0/openshift-svcat-apiserver/operator-config.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/role-extension-apiserver-auth-reader.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/rolebinding-extension-apiserver-auth-reader.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/sa.yaml
@@ -501,27 +499,6 @@ func v3110OpenshiftSvcatApiserverCrbServiceclassViewerBindingYaml() (*asset, err
 	return a, nil
 }
 
-var _v3110OpenshiftSvcatApiserverDefaultconfigYaml = []byte(`apiVersion: openshiftcontrolplane.config.openshift.io/v1
-kind: OpenShiftAPIServerConfig
-aggregatorConfig:
-
-`)
-
-func v3110OpenshiftSvcatApiserverDefaultconfigYamlBytes() ([]byte, error) {
-	return _v3110OpenshiftSvcatApiserverDefaultconfigYaml, nil
-}
-
-func v3110OpenshiftSvcatApiserverDefaultconfigYaml() (*asset, error) {
-	bytes, err := v3110OpenshiftSvcatApiserverDefaultconfigYamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "v3.11.0/openshift-svcat-apiserver/defaultconfig.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
 var _v3110OpenshiftSvcatApiserverDsYaml = []byte(`apiVersion: "apps/v1"
 kind: DaemonSet
 metadata:
@@ -651,32 +628,6 @@ func v3110OpenshiftSvcatApiserverNsYaml() (*asset, error) {
 	}
 
 	info := bindataFileInfo{name: "v3.11.0/openshift-svcat-apiserver/ns.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
-var _v3110OpenshiftSvcatApiserverOperatorConfigYaml = []byte(`apiVersion: operator.openshift.io/v1
-kind: OpenShiftAPIServer
-metadata:
-  name: cluster
-spec:
-  logLevel: "Normal"
-  managementState: Managed
-  operandSpecs: null
-  unsupportedConfigOverrides: null
-`)
-
-func v3110OpenshiftSvcatApiserverOperatorConfigYamlBytes() ([]byte, error) {
-	return _v3110OpenshiftSvcatApiserverOperatorConfigYaml, nil
-}
-
-func v3110OpenshiftSvcatApiserverOperatorConfigYaml() (*asset, error) {
-	bytes, err := v3110OpenshiftSvcatApiserverOperatorConfigYamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "v3.11.0/openshift-svcat-apiserver/operator-config.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -861,10 +812,8 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.11.0/openshift-svcat-apiserver/crb-readiness-binding.yaml":                       v3110OpenshiftSvcatApiserverCrbReadinessBindingYaml,
 	"v3.11.0/openshift-svcat-apiserver/crb-sar-creator-binding.yaml":                     v3110OpenshiftSvcatApiserverCrbSarCreatorBindingYaml,
 	"v3.11.0/openshift-svcat-apiserver/crb-serviceclass-viewer-binding.yaml":             v3110OpenshiftSvcatApiserverCrbServiceclassViewerBindingYaml,
-	"v3.11.0/openshift-svcat-apiserver/defaultconfig.yaml":                               v3110OpenshiftSvcatApiserverDefaultconfigYaml,
 	"v3.11.0/openshift-svcat-apiserver/ds.yaml":                                          v3110OpenshiftSvcatApiserverDsYaml,
 	"v3.11.0/openshift-svcat-apiserver/ns.yaml":                                          v3110OpenshiftSvcatApiserverNsYaml,
-	"v3.11.0/openshift-svcat-apiserver/operator-config.yaml":                             v3110OpenshiftSvcatApiserverOperatorConfigYaml,
 	"v3.11.0/openshift-svcat-apiserver/role-extension-apiserver-auth-reader.yaml":        v3110OpenshiftSvcatApiserverRoleExtensionApiserverAuthReaderYaml,
 	"v3.11.0/openshift-svcat-apiserver/rolebinding-extension-apiserver-auth-reader.yaml": v3110OpenshiftSvcatApiserverRolebindingExtensionApiserverAuthReaderYaml,
 	"v3.11.0/openshift-svcat-apiserver/sa.yaml":                                          v3110OpenshiftSvcatApiserverSaYaml,
@@ -914,23 +863,21 @@ type bintree struct {
 var _bintree = &bintree{nil, map[string]*bintree{
 	"v3.11.0": {nil, map[string]*bintree{
 		"openshift-svcat-apiserver": {nil, map[string]*bintree{
-			"cm.yaml":                                          {v3110OpenshiftSvcatApiserverCmYaml, map[string]*bintree{}},
-			"cr-aggregate-to-admin.yaml":                       {v3110OpenshiftSvcatApiserverCrAggregateToAdminYaml, map[string]*bintree{}},
-			"cr-aggregate-to-edit.yaml":                        {v3110OpenshiftSvcatApiserverCrAggregateToEditYaml, map[string]*bintree{}},
-			"cr-aggregate-to-view.yaml":                        {v3110OpenshiftSvcatApiserverCrAggregateToViewYaml, map[string]*bintree{}},
-			"cr-namespace-viewer.yaml":                         {v3110OpenshiftSvcatApiserverCrNamespaceViewerYaml, map[string]*bintree{}},
-			"cr-readiness-probe.yaml":                          {v3110OpenshiftSvcatApiserverCrReadinessProbeYaml, map[string]*bintree{}},
-			"cr-sar-creator.yaml":                              {v3110OpenshiftSvcatApiserverCrSarCreatorYaml, map[string]*bintree{}},
-			"cr-serviceclass-viewer.yaml":                      {v3110OpenshiftSvcatApiserverCrServiceclassViewerYaml, map[string]*bintree{}},
-			"crb-auth-delegator-binding.yaml":                  {v3110OpenshiftSvcatApiserverCrbAuthDelegatorBindingYaml, map[string]*bintree{}},
-			"crb-namespace-viewer-binding.yaml":                {v3110OpenshiftSvcatApiserverCrbNamespaceViewerBindingYaml, map[string]*bintree{}},
-			"crb-readiness-binding.yaml":                       {v3110OpenshiftSvcatApiserverCrbReadinessBindingYaml, map[string]*bintree{}},
-			"crb-sar-creator-binding.yaml":                     {v3110OpenshiftSvcatApiserverCrbSarCreatorBindingYaml, map[string]*bintree{}},
-			"crb-serviceclass-viewer-binding.yaml":             {v3110OpenshiftSvcatApiserverCrbServiceclassViewerBindingYaml, map[string]*bintree{}},
-			"defaultconfig.yaml":                               {v3110OpenshiftSvcatApiserverDefaultconfigYaml, map[string]*bintree{}},
-			"ds.yaml":                                          {v3110OpenshiftSvcatApiserverDsYaml, map[string]*bintree{}},
-			"ns.yaml":                                          {v3110OpenshiftSvcatApiserverNsYaml, map[string]*bintree{}},
-			"operator-config.yaml":                             {v3110OpenshiftSvcatApiserverOperatorConfigYaml, map[string]*bintree{}},
+			"cm.yaml":                              {v3110OpenshiftSvcatApiserverCmYaml, map[string]*bintree{}},
+			"cr-aggregate-to-admin.yaml":           {v3110OpenshiftSvcatApiserverCrAggregateToAdminYaml, map[string]*bintree{}},
+			"cr-aggregate-to-edit.yaml":            {v3110OpenshiftSvcatApiserverCrAggregateToEditYaml, map[string]*bintree{}},
+			"cr-aggregate-to-view.yaml":            {v3110OpenshiftSvcatApiserverCrAggregateToViewYaml, map[string]*bintree{}},
+			"cr-namespace-viewer.yaml":             {v3110OpenshiftSvcatApiserverCrNamespaceViewerYaml, map[string]*bintree{}},
+			"cr-readiness-probe.yaml":              {v3110OpenshiftSvcatApiserverCrReadinessProbeYaml, map[string]*bintree{}},
+			"cr-sar-creator.yaml":                  {v3110OpenshiftSvcatApiserverCrSarCreatorYaml, map[string]*bintree{}},
+			"cr-serviceclass-viewer.yaml":          {v3110OpenshiftSvcatApiserverCrServiceclassViewerYaml, map[string]*bintree{}},
+			"crb-auth-delegator-binding.yaml":      {v3110OpenshiftSvcatApiserverCrbAuthDelegatorBindingYaml, map[string]*bintree{}},
+			"crb-namespace-viewer-binding.yaml":    {v3110OpenshiftSvcatApiserverCrbNamespaceViewerBindingYaml, map[string]*bintree{}},
+			"crb-readiness-binding.yaml":           {v3110OpenshiftSvcatApiserverCrbReadinessBindingYaml, map[string]*bintree{}},
+			"crb-sar-creator-binding.yaml":         {v3110OpenshiftSvcatApiserverCrbSarCreatorBindingYaml, map[string]*bintree{}},
+			"crb-serviceclass-viewer-binding.yaml": {v3110OpenshiftSvcatApiserverCrbServiceclassViewerBindingYaml, map[string]*bintree{}},
+			"ds.yaml": {v3110OpenshiftSvcatApiserverDsYaml, map[string]*bintree{}},
+			"ns.yaml": {v3110OpenshiftSvcatApiserverNsYaml, map[string]*bintree{}},
 			"role-extension-apiserver-auth-reader.yaml":        {v3110OpenshiftSvcatApiserverRoleExtensionApiserverAuthReaderYaml, map[string]*bintree{}},
 			"rolebinding-extension-apiserver-auth-reader.yaml": {v3110OpenshiftSvcatApiserverRolebindingExtensionApiserverAuthReaderYaml, map[string]*bintree{}},
 			"sa.yaml":  {v3110OpenshiftSvcatApiserverSaYaml, map[string]*bintree{}},

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00.go
@@ -215,11 +215,6 @@ func syncServiceCatalogAPIServer_v311_00_to_latest(c ServiceCatalogAPIServerOper
 
 func manageServiceCatalogAPIServerConfigMap_v311_00_to_latest(kubeClient kubernetes.Interface, client coreclientv1.ConfigMapsGetter, recorder events.Recorder, operatorConfig *operatorv1.ServiceCatalogAPIServer) (*corev1.ConfigMap, bool, error) {
 	configMap := resourceread.ReadConfigMapV1OrDie(v311_00_assets.MustAsset("v3.11.0/openshift-svcat-apiserver/cm.yaml"))
-	defaultConfig := v311_00_assets.MustAsset("v3.11.0/openshift-svcat-apiserver/defaultconfig.yaml")
-	requiredConfigMap, _, err := resourcemerge.MergeConfigMap(configMap, "config.yaml", nil, defaultConfig, operatorConfig.Spec.ObservedConfig.Raw, operatorConfig.Spec.UnsupportedConfigOverrides.Raw)
-	if err != nil {
-		return nil, false, err
-	}
 
 	// we can embed input hashes on our main configmap to drive rollouts when they change.
 	inputHashes, err := resourcehash.MultipleObjectHashStringMapForObjectReferences(
@@ -234,10 +229,10 @@ func manageServiceCatalogAPIServerConfigMap_v311_00_to_latest(kubeClient kuberne
 		return nil, false, err
 	}
 	for k, v := range inputHashes {
-		requiredConfigMap.Data[k] = v
+		configMap.Data[k] = v
 	}
 
-	return resourceapply.ApplyConfigMap(client, recorder, requiredConfigMap)
+	return resourceapply.ApplyConfigMap(client, recorder, configMap)
 }
 
 func manageServiceCatalogAPIServerDaemonSet_v311_00_to_latest(client appsclientv1.DaemonSetsGetter, recorder events.Recorder, imagePullSpec string, operatorConfig *operatorv1.ServiceCatalogAPIServer, generationStatus []operatorv1.GenerationStatus, forceRollingUpdate bool) (*appsv1.DaemonSet, bool, error) {


### PR DESCRIPTION
There was some left over remnants from when this operator was first copied from the Cluster OpenShiftAPIServer Operator.   Specifically we were still referencing defaultconfig and operator-config which weren't used and were actually referencing OpenShiftAPIServerConfig and OpenShiftAPIServer resources.  

Remove these resources and don't include them in any of the sync.