### PR TITLE
Bug 1685332: set priorityClassName to system-cluster-critical

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ spec:
 EOF
 ```
 Once the cluster `ServiceCatalogAPIServer` is found to exist and have a `managementState` of `Managed` the operator will create necessary resources in the
-`kube-service-catalog` namespace for deploying the Service Catalog API Server.
+`openshift-service-catalog` namespace for deploying the Service Catalog API Server.
 
-Watch for service catalog apiservers to come up in the kube-service-catalog namespace.
+Watch for service catalog apiservers to come up in the openshift-service-catalog namespace.
 
 ## Verification & debugging
 Nothing happens without the CR:

--- a/bindata/v3.11.0/openshift-svcat-apiserver/cm.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
   name: config
 data:
   config.yaml:

--- a/bindata/v3.11.0/openshift-svcat-apiserver/crb-auth-delegator-binding.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/crb-auth-delegator-binding.yaml
@@ -8,4 +8,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog

--- a/bindata/v3.11.0/openshift-svcat-apiserver/crb-namespace-viewer-binding.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/crb-namespace-viewer-binding.yaml
@@ -8,4 +8,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog

--- a/bindata/v3.11.0/openshift-svcat-apiserver/crb-sar-creator-binding.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/crb-sar-creator-binding.yaml
@@ -8,4 +8,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog

--- a/bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
 spec:
   selector:
     matchLabels:
@@ -21,6 +21,7 @@ spec:
       serviceAccountName: service-catalog-apiserver
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       containers:
       - args:
         - apiserver

--- a/bindata/v3.11.0/openshift-svcat-apiserver/ns.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/ns.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kube-service-catalog
+  name: openshift-service-catalog
   labels:
     openshift.io/run-level: "1"

--- a/bindata/v3.11.0/openshift-svcat-apiserver/rolebinding-extension-apiserver-auth-reader.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/rolebinding-extension-apiserver-auth-reader.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog

--- a/bindata/v3.11.0/openshift-svcat-apiserver/sa.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/sa.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
   name: service-catalog-apiserver

--- a/bindata/v3.11.0/openshift-svcat-apiserver/svc.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
   name: api
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -20,7 +20,7 @@ spec:
       containers:
       - name: operator
         image: registry.svc.ci.openshift.org/openshift/origin-v4.0:cluster-svcat-apiserver-operator
-        imagePullPolicy: Always
+        imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 8443
           name: metrics
@@ -50,5 +50,6 @@ spec:
           name: openshift-svcat-apiserver-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists

--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -6,5 +6,5 @@ const (
 	UserSpecifiedGlobalConfigNamespace    = "openshift-config"
 	MachineSpecifiedGlobalConfigNamespace = "openshift-config-managed"
 	OperatorNamespace                     = "openshift-svcat-apiserver-operator"
-	TargetNamespaceName                   = "kube-service-catalog"
+	TargetNamespaceName                   = "openshift-service-catalog"
 )

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -66,7 +66,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _v3110OpenshiftSvcatApiserverCmYaml = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
   name: config
 data:
   config.yaml:
@@ -364,7 +364,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
 `)
 
 func v3110OpenshiftSvcatApiserverCrbAuthDelegatorBindingYamlBytes() ([]byte, error) {
@@ -392,7 +392,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
 `)
 
 func v3110OpenshiftSvcatApiserverCrbNamespaceViewerBindingYamlBytes() ([]byte, error) {
@@ -452,7 +452,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
 `)
 
 func v3110OpenshiftSvcatApiserverCrbSarCreatorBindingYamlBytes() ([]byte, error) {
@@ -505,7 +505,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
 spec:
   selector:
     matchLabels:
@@ -522,6 +522,7 @@ spec:
       serviceAccountName: service-catalog-apiserver
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       containers:
       - args:
         - apiserver
@@ -613,7 +614,7 @@ func v3110OpenshiftSvcatApiserverDsYaml() (*asset, error) {
 var _v3110OpenshiftSvcatApiserverNsYaml = []byte(`apiVersion: v1
 kind: Namespace
 metadata:
-  name: kube-service-catalog
+  name: openshift-service-catalog
   labels:
     openshift.io/run-level: "1"`)
 
@@ -674,7 +675,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
 `)
 
 func v3110OpenshiftSvcatApiserverRolebindingExtensionApiserverAuthReaderYamlBytes() ([]byte, error) {
@@ -695,7 +696,7 @@ func v3110OpenshiftSvcatApiserverRolebindingExtensionApiserverAuthReaderYaml() (
 var _v3110OpenshiftSvcatApiserverSaYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
   name: service-catalog-apiserver
 `)
 
@@ -717,7 +718,7 @@ func v3110OpenshiftSvcatApiserverSaYaml() (*asset, error) {
 var _v3110OpenshiftSvcatApiserverSvcYaml = []byte(`apiVersion: v1
 kind: Service
 metadata:
-  namespace: kube-service-catalog
+  namespace: openshift-service-catalog
   name: api
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
@@ -106,12 +106,12 @@ func TestProgressingCondition(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			kubeClient := fake.NewSimpleClientset(
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "serving-cert", Namespace: "kube-service-catalog"}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "serving-cert", Namespace: "openshift-service-catalog"}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client", Namespace: "kube-system"}},
 				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "apiserver",
-						Namespace:  "kube-service-catalog",
+						Namespace:  "openshift-service-catalog",
 						Generation: tc.daemonSetGeneration,
 					},
 					Status: appsv1.DaemonSetStatus{
@@ -223,11 +223,11 @@ func TestAvailableStatus(t *testing.T) {
 			expectedStatus:          operatorv1.ConditionFalse,
 			expectedReason:          "NoDaemon",
 			expectedMessages:        []string{"daemonset/apiserver.openshift-svcat-apiserver: could not be retrieved"},
-			expectedFailingMessages: []string{"\"daemonsets\": TEST ERROR: fail to get daemonset/apiserver.kube-service-catalog"},
+			expectedFailingMessages: []string{"\"daemonsets\": TEST ERROR: fail to get daemonset/apiserver.openshift-service-catalog"},
 
 			daemonReactor: func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-				if action.GetVerb() == "get" && action.GetNamespace() == "kube-service-catalog" && action.(kubetesting.GetAction).GetName() == "apiserver" {
-					return true, nil, errors.New("TEST ERROR: fail to get daemonset/apiserver.kube-service-catalog")
+				if action.GetVerb() == "get" && action.GetNamespace() == "openshift-service-catalog" && action.(kubetesting.GetAction).GetName() == "apiserver" {
+					return true, nil, errors.New("TEST ERROR: fail to get daemonset/apiserver.openshift-service-catalog")
 				}
 				return false, nil, nil
 			},
@@ -239,9 +239,9 @@ func TestAvailableStatus(t *testing.T) {
 			expectedMessages: []string{"no openshift-svcat-apiserver daemon pods available on any node."},
 
 			daemonReactor: func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-				if action.GetVerb() == "get" && action.GetNamespace() == "kube-service-catalog" && action.(kubetesting.GetAction).GetName() == "apiserver" {
+				if action.GetVerb() == "get" && action.GetNamespace() == "openshift-service-catalog" && action.(kubetesting.GetAction).GetName() == "apiserver" {
 					return true, &appsv1.DaemonSet{
-						ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "kube-service-catalog"},
+						ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-service-catalog"},
 						Status:     appsv1.DaemonSetStatus{NumberAvailable: 0},
 					}, nil
 				}
@@ -281,12 +281,12 @@ func TestAvailableStatus(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			kubeClient := fake.NewSimpleClientset(
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "serving-cert", Namespace: "kube-service-catalog"}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "serving-cert", Namespace: "openshift-service-catalog"}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client", Namespace: "kube-system"}},
 				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "apiserver",
-						Namespace:  "kube-service-catalog",
+						Namespace:  "openshift-service-catalog",
 						Generation: 99,
 					},
 					Status: appsv1.DaemonSetStatus{


### PR DESCRIPTION
For both the operator and operand, set priorityClassName="system-cluster-critical"

see: openshift/origin#22217

This requires changing the namespace from kube-service-catalog to openshift-service-catalog.  

**`system-cluster-critical`:   `Error creating: pods "apiserver-" is forbidden: pods with system-cluster-critical priorityClass is not permitted in kube-service-catalog namespace`**

Discussed and ok'd by Derek.