### PR TITLE
use consistent namespaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Once the operator detects the CR it will create the Service Catalog API Server C
 2. `make images`
 3. `docker tag openshift/origin-cluster-svcat-apiserver-operator:latest <yourdockerhubid>/origin-cluster-svcat-apiserver-operator:latest`
 4. `docker push <yourdockerhubid>/origin-cluster-svcat-apiserver-operator:latest`
-5. edit manifests/0000_61_openshift-svcat-apiserver-operator_08_deployment.yaml and update the containers/image to `<yourdockerhubid>/origin-cluster-svcat-apiserver-operator:latest` and set the pull policy to `Always`
+5. edit manifests/0000_61_openshift-service-catalog-apiserver-operator_08_deployment.yaml and update the containers/image to `<yourdockerhubid>/origin-cluster-svcat-apiserver-operator:latest` and set the pull policy to `Always`
 6.  `oc apply -f manifests`
 
 This will cause the creation of the cluster-svcat-apiserver-operator deployment 
@@ -30,9 +30,9 @@ spec:
 EOF
 ```
 Once the cluster `ServiceCatalogAPIServer` is found to exist and have a `managementState` of `Managed` the operator will create necessary resources in the
-`openshift-service-catalog` namespace for deploying the Service Catalog API Server.
+`openshift-service-catalog-apiserver` namespace for deploying the Service Catalog API Server.
 
-Watch for service catalog apiservers to come up in the openshift-service-catalog namespace.
+Watch for service catalog apiservers to come up in the openshift-service-catalog-apiserver namespace.
 
 ## Verification & debugging
 Nothing happens without the CR:
@@ -54,7 +54,7 @@ Review operator pod logs from the `openshift-svcat-apiserver` namespace to see d
 
 The operator deployment events will give you an overview of what it's done.  Ensure its not looping & review the events:
 ```
-$ oc describe deployment openshift-svcat-apiserver-operator -n openshift-svcat-apiserver-operator
+$ oc describe deployment openshift-service-catalog-apiserver-operator -n openshift-service-catalog-apiserver-operator
 ```
 
 

--- a/bindata/v3.11.0/openshift-svcat-apiserver/cm.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/cm.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
   name: config
 data:
   config.yaml:

--- a/bindata/v3.11.0/openshift-svcat-apiserver/crb-auth-delegator-binding.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/crb-auth-delegator-binding.yaml
@@ -8,4 +8,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver

--- a/bindata/v3.11.0/openshift-svcat-apiserver/crb-namespace-viewer-binding.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/crb-namespace-viewer-binding.yaml
@@ -8,4 +8,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver

--- a/bindata/v3.11.0/openshift-svcat-apiserver/crb-sar-creator-binding.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/crb-sar-creator-binding.yaml
@@ -8,4 +8,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver

--- a/bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
 spec:
   selector:
     matchLabels:

--- a/bindata/v3.11.0/openshift-svcat-apiserver/ns.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/ns.yaml
@@ -1,6 +1,6 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-service-catalog
+  name: openshift-service-catalog-apiserver
   labels:
     openshift.io/run-level: "1"

--- a/bindata/v3.11.0/openshift-svcat-apiserver/rolebinding-extension-apiserver-auth-reader.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/rolebinding-extension-apiserver-auth-reader.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver

--- a/bindata/v3.11.0/openshift-svcat-apiserver/sa.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/sa.yaml
@@ -1,5 +1,5 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
   name: service-catalog-apiserver

--- a/bindata/v3.11.0/openshift-svcat-apiserver/svc.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/svc.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
   name: api
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert

--- a/manifests/0000_90_cluster-svcat-apiserver-operator_00_prometheusrole.yaml
+++ b/manifests/0000_90_cluster-svcat-apiserver-operator_00_prometheusrole.yaml
@@ -3,7 +3,7 @@ kind: Role
 metadata:
   # TODO this should be a clusterrole
   name: prometheus-k8s
-  namespace: openshift-svcat-apiserver-operator
+  namespace: openshift-service-catalog-apiserver-operator
 rules:
 - apiGroups:
   - ""

--- a/manifests/0000_90_cluster-svcat-apiserver-operator_01_prometheusrolebinding.yaml
+++ b/manifests/0000_90_cluster-svcat-apiserver-operator_01_prometheusrolebinding.yaml
@@ -2,7 +2,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
   name: prometheus-k8s
-  namespace: openshift-svcat-apiserver-operator
+  namespace: openshift-service-catalog-apiserver-operator
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role

--- a/manifests/0000_90_cluster-svcat-apiserver-operator_02-operator-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-svcat-apiserver-operator_02-operator-servicemonitor.yaml
@@ -1,8 +1,8 @@
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
-  name: openshift-svcat-apiserver-operator
-  namespace: openshift-svcat-apiserver-operator
+  name: openshift-service-catalog-apiserver-operator
+  namespace: openshift-service-catalog-apiserver-operator
 spec:
   endpoints:
   - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -17,11 +17,11 @@ spec:
     tlsConfig:
       # TODO where do you mount the service-ca.crt?
       insecureSkipVerify: true
-      serverName: metrics.openshift-svcat-apiserver-operator.svc
+      serverName: metrics.openshift-service-catalog-apiserver-operator.svc
   jobLabel: component
   namespaceSelector:
     matchNames:
-    - openshift-svcat-apiserver-operator
+    - openshift-service-catalog-apiserver-operator
   selector:
     matchLabels:
-      app: openshift-svcat-apiserver-operator
+      app: openshift-service-catalog-apiserver-operator

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   labels:
-  name: openshift-svcat-apiserver-operator
+  name: openshift-service-catalog-apiserver-operator

--- a/manifests/03_configmap.yaml
+++ b/manifests/03_configmap.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: openshift-svcat-apiserver-operator
-  name: openshift-svcat-apiserver-operator-config
+  namespace: openshift-service-catalog-apiserver-operator
+  name: openshift-service-catalog-apiserver-operator-config
 data:
   config.yaml: |
     apiVersion: operator.openshift.io/v1alpha1

--- a/manifests/04_roles.yaml
+++ b/manifests/04_roles.yaml
@@ -1,11 +1,11 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: system:openshift:operator:openshift-svcat-apiserver-operator
+  name: system:openshift:operator:openshift-service-catalog-apiserver-operator
 roleRef:
   kind: ClusterRole
   name: cluster-admin
 subjects:
 - kind: ServiceAccount
-  namespace: openshift-svcat-apiserver-operator
-  name: openshift-svcat-apiserver-operator
+  namespace: openshift-service-catalog-apiserver-operator
+  name: openshift-service-catalog-apiserver-operator

--- a/manifests/05_serviceaccount.yaml
+++ b/manifests/05_serviceaccount.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: openshift-svcat-apiserver-operator
-  name: openshift-svcat-apiserver-operator
+  namespace: openshift-service-catalog-apiserver-operator
+  name: openshift-service-catalog-apiserver-operator
   labels:
-    app: openshift-svcat-apiserver-operator
+    app: openshift-service-catalog-apiserver-operator

--- a/manifests/06_service.yaml
+++ b/manifests/06_service.yaml
@@ -2,11 +2,11 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    service.alpha.openshift.io/serving-cert-secret-name: openshift-svcat-apiserver-operator-serving-cert
+    service.alpha.openshift.io/serving-cert-secret-name: openshift-service-catalog-apiserver-operator-serving-cert
   labels:
-    app: openshift-svcat-apiserver-operator
+    app: openshift-service-catalog-apiserver-operator
   name: metrics
-  namespace: openshift-svcat-apiserver-operator
+  namespace: openshift-service-catalog-apiserver-operator
 spec:
   ports:
   - name: https
@@ -14,6 +14,6 @@ spec:
     protocol: TCP
     targetPort: 8443
   selector:
-    app: openshift-svcat-apiserver-operator
+    app: openshift-service-catalog-apiserver-operator
   type: ClusterIP
 

--- a/manifests/07_deployment.yaml
+++ b/manifests/07_deployment.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  namespace: openshift-svcat-apiserver-operator
-  name: openshift-svcat-apiserver-operator
+  namespace: openshift-service-catalog-apiserver-operator
+  name: openshift-service-catalog-apiserver-operator
   labels:
-    app: openshift-svcat-apiserver-operator
+    app: openshift-service-catalog-apiserver-operator
 spec:
   replicas: 1
   selector:
     matchLabels:
-      app: openshift-svcat-apiserver-operator
+      app: openshift-service-catalog-apiserver-operator
   template:
     metadata:
-      name: openshift-svcat-apiserver-operator
+      name: openshift-service-catalog-apiserver-operator
       labels:
-        app: openshift-svcat-apiserver-operator
+        app: openshift-service-catalog-apiserver-operator
     spec:
-      serviceAccountName: openshift-svcat-apiserver-operator
+      serviceAccountName: openshift-service-catalog-apiserver-operator
       containers:
       - name: operator
         image: registry.svc.ci.openshift.org/openshift/origin-v4.0:cluster-svcat-apiserver-operator
@@ -43,11 +43,11 @@ spec:
       volumes:
       - name: serving-cert
         secret:
-          secretName: openshift-svcat-apiserver-operator-serving-cert
+          secretName: openshift-service-catalog-apiserver-operator-serving-cert
           optional: true
       - name: config
         configMap:
-          name: openshift-svcat-apiserver-operator-config
+          name: openshift-service-catalog-apiserver-operator-config
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: "system-cluster-critical"

--- a/pkg/operator/operatorclient/interfaces.go
+++ b/pkg/operator/operatorclient/interfaces.go
@@ -5,6 +5,6 @@ const (
 	KubeAPIServerNamespaceName            = "openshift-kube-apiserver"
 	UserSpecifiedGlobalConfigNamespace    = "openshift-config"
 	MachineSpecifiedGlobalConfigNamespace = "openshift-config-managed"
-	OperatorNamespace                     = "openshift-svcat-apiserver-operator"
-	TargetNamespaceName                   = "openshift-service-catalog"
+	OperatorNamespace                     = "openshift-service-catalog-apiserver-operator"
+	TargetNamespaceName                   = "openshift-service-catalog-apiserver"
 )

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -67,7 +67,7 @@ func (fi bindataFileInfo) Sys() interface{} {
 var _v3110OpenshiftSvcatApiserverCmYaml = []byte(`apiVersion: v1
 kind: ConfigMap
 metadata:
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
   name: config
 data:
   config.yaml:
@@ -365,7 +365,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
 `)
 
 func v3110OpenshiftSvcatApiserverCrbAuthDelegatorBindingYamlBytes() ([]byte, error) {
@@ -393,7 +393,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
 `)
 
 func v3110OpenshiftSvcatApiserverCrbNamespaceViewerBindingYamlBytes() ([]byte, error) {
@@ -453,7 +453,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
 `)
 
 func v3110OpenshiftSvcatApiserverCrbSarCreatorBindingYamlBytes() ([]byte, error) {
@@ -506,7 +506,7 @@ metadata:
   labels:
     app: apiserver
   name: apiserver
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
 spec:
   selector:
     matchLabels:
@@ -615,7 +615,7 @@ func v3110OpenshiftSvcatApiserverDsYaml() (*asset, error) {
 var _v3110OpenshiftSvcatApiserverNsYaml = []byte(`apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-service-catalog
+  name: openshift-service-catalog-apiserver
   labels:
     openshift.io/run-level: "1"`)
 
@@ -700,7 +700,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: service-catalog-apiserver
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
 `)
 
 func v3110OpenshiftSvcatApiserverRolebindingExtensionApiserverAuthReaderYamlBytes() ([]byte, error) {
@@ -721,7 +721,7 @@ func v3110OpenshiftSvcatApiserverRolebindingExtensionApiserverAuthReaderYaml() (
 var _v3110OpenshiftSvcatApiserverSaYaml = []byte(`apiVersion: v1
 kind: ServiceAccount
 metadata:
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
   name: service-catalog-apiserver
 `)
 
@@ -743,7 +743,7 @@ func v3110OpenshiftSvcatApiserverSaYaml() (*asset, error) {
 var _v3110OpenshiftSvcatApiserverSvcYaml = []byte(`apiVersion: v1
 kind: Service
 metadata:
-  namespace: openshift-service-catalog
+  namespace: openshift-service-catalog-apiserver
   name: api
   annotations:
     service.alpha.openshift.io/serving-cert-secret-name: serving-cert

--- a/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
+++ b/pkg/operator/workloadcontroller/workload_controller_openshiftapiserver_v311_00_test.go
@@ -106,12 +106,12 @@ func TestProgressingCondition(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			kubeClient := fake.NewSimpleClientset(
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "serving-cert", Namespace: "openshift-service-catalog"}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "serving-cert", Namespace: operatorclient.TargetNamespaceName}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client", Namespace: "kube-system"}},
 				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "apiserver",
-						Namespace:  "openshift-service-catalog",
+						Namespace:  operatorclient.TargetNamespaceName,
 						Generation: tc.daemonSetGeneration,
 					},
 					Status: appsv1.DaemonSetStatus{
@@ -223,11 +223,11 @@ func TestAvailableStatus(t *testing.T) {
 			expectedStatus:          operatorv1.ConditionFalse,
 			expectedReason:          "NoDaemon",
 			expectedMessages:        []string{"daemonset/apiserver.openshift-svcat-apiserver: could not be retrieved"},
-			expectedFailingMessages: []string{"\"daemonsets\": TEST ERROR: fail to get daemonset/apiserver.openshift-service-catalog"},
+			expectedFailingMessages: []string{"\"daemonsets\": TEST ERROR: fail to get daemonset/apiserver.openshift-service-catalog-apiserver"},
 
 			daemonReactor: func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-				if action.GetVerb() == "get" && action.GetNamespace() == "openshift-service-catalog" && action.(kubetesting.GetAction).GetName() == "apiserver" {
-					return true, nil, errors.New("TEST ERROR: fail to get daemonset/apiserver.openshift-service-catalog")
+				if action.GetVerb() == "get" && action.GetNamespace() == operatorclient.TargetNamespaceName && action.(kubetesting.GetAction).GetName() == "apiserver" {
+					return true, nil, errors.New("TEST ERROR: fail to get daemonset/apiserver.openshift-service-catalog-apiserver")
 				}
 				return false, nil, nil
 			},
@@ -239,9 +239,9 @@ func TestAvailableStatus(t *testing.T) {
 			expectedMessages: []string{"no openshift-svcat-apiserver daemon pods available on any node."},
 
 			daemonReactor: func(action kubetesting.Action) (handled bool, ret runtime.Object, err error) {
-				if action.GetVerb() == "get" && action.GetNamespace() == "openshift-service-catalog" && action.(kubetesting.GetAction).GetName() == "apiserver" {
+				if action.GetVerb() == "get" && action.GetNamespace() == operatorclient.TargetNamespaceName && action.(kubetesting.GetAction).GetName() == "apiserver" {
 					return true, &appsv1.DaemonSet{
-						ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: "openshift-service-catalog"},
+						ObjectMeta: metav1.ObjectMeta{Name: "apiserver", Namespace: operatorclient.TargetNamespaceName},
 						Status:     appsv1.DaemonSetStatus{NumberAvailable: 0},
 					}, nil
 				}
@@ -281,12 +281,12 @@ func TestAvailableStatus(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 
 			kubeClient := fake.NewSimpleClientset(
-				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "serving-cert", Namespace: "openshift-service-catalog"}},
+				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "serving-cert", Namespace: operatorclient.TargetNamespaceName}},
 				&corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: "etcd-client", Namespace: "kube-system"}},
 				&appsv1.DaemonSet{
 					ObjectMeta: metav1.ObjectMeta{
 						Name:       "apiserver",
-						Namespace:  "openshift-service-catalog",
+						Namespace:  operatorclient.TargetNamespaceName,
 						Generation: 99,
 					},
 					Status: appsv1.DaemonSetStatus{


### PR DESCRIPTION
I realized the namespaces are rather inconsistent.

The operand namespace was "kube-service-catalog".  We decided to split the controller manager out to "kube-service-catalog-controller-manager" to be consistent with the openshift apiserver/controller manager.

#36 added priorityClassName and forced changing the operand namespace to a system namespace so "kube-service-catalog" was changed to "openshift-service-catalog".  

The operator namespace was "openshift-svcat-apiserver-operator"

A bit confusing, yes?  To make things consistent, this PR changes the following:
operand namespace:  openshift-service-catalog-apiserver
operator namespace:  openshift-service-catalog-apiserver-operator

This also follows the convention used by openshift apiserver/controller manager and their operands.

I'll open a request with network team to update the namespaces/netids.