### PR TITLE
Use the CVO to manage operator config

### DIFF
--- a/manifests/03_config.cr.yaml
+++ b/manifests/03_config.cr.yaml
@@ -2,6 +2,8 @@ apiVersion: operator.openshift.io/v1
 kind: ServiceCatalogAPIServer
 metadata:
   name: cluster
+  annotations:
+    release.openshift.io/create-only: "true"
 spec:
   logLevel: Normal
   managementState: Removed

--- a/pkg/operator/starter.go
+++ b/pkg/operator/starter.go
@@ -7,11 +7,9 @@ import (
 
 	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/operator/operatorclient"
 	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/operator/resourcesynccontroller"
-	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/operator/v311_00_assets"
 	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/operator/workloadcontroller"
 
 	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
 	configv1client "github.com/openshift/client-go/config/clientset/versioned"
 	configinformers "github.com/openshift/client-go/config/informers/externalversions"
 	operatorv1client "github.com/openshift/client-go/operator/clientset/versioned"
@@ -22,8 +20,6 @@ import (
 	"github.com/openshift/library-go/pkg/operator/v1helpers"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
-	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	apiregistrationclient "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset"
 	apiregistrationinformers "k8s.io/kube-aggregator/pkg/client/informers/externalversions"
@@ -46,16 +42,6 @@ func RunOperator(ctx *controllercmd.ControllerContext) error {
 	if err != nil {
 		return err
 	}
-	dynamicClient, err := dynamic.NewForConfig(ctx.KubeConfig)
-	if err != nil {
-		return err
-	}
-
-	v1helpers.EnsureOperatorConfigExists(
-		dynamicClient,
-		v311_00_assets.MustAsset("v3.11.0/openshift-svcat-apiserver/operator-config.yaml"),
-		schema.GroupVersionResource{Group: operatorv1.GroupName, Version: operatorv1.GroupVersion.Version, Resource: "servicecatalogapiservers"},
-	)
 
 	operatorConfigInformers := operatorv1informers.NewSharedInformerFactory(operatorConfigClient, 10*time.Minute)
 	kubeInformersForNamespaces := v1helpers.NewKubeInformersForNamespaces(kubeClient,

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -15,7 +15,6 @@
 // bindata/v3.11.0/openshift-svcat-apiserver/crb-serviceclass-viewer-binding.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/ns.yaml
-// bindata/v3.11.0/openshift-svcat-apiserver/operator-config.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/role-extension-apiserver-auth-reader.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/rolebinding-extension-apiserver-auth-reader.yaml
 // bindata/v3.11.0/openshift-svcat-apiserver/sa.yaml
@@ -654,30 +653,6 @@ func v3110OpenshiftSvcatApiserverNsYaml() (*asset, error) {
 	return a, nil
 }
 
-var _v3110OpenshiftSvcatApiserverOperatorConfigYaml = []byte(`apiVersion: operator.openshift.io/v1
-kind: ServiceCatalogAPIServer
-metadata:
-  name: cluster
-spec:
-  logLevel: Normal
-  managementState: Removed
-`)
-
-func v3110OpenshiftSvcatApiserverOperatorConfigYamlBytes() ([]byte, error) {
-	return _v3110OpenshiftSvcatApiserverOperatorConfigYaml, nil
-}
-
-func v3110OpenshiftSvcatApiserverOperatorConfigYaml() (*asset, error) {
-	bytes, err := v3110OpenshiftSvcatApiserverOperatorConfigYamlBytes()
-	if err != nil {
-		return nil, err
-	}
-
-	info := bindataFileInfo{name: "v3.11.0/openshift-svcat-apiserver/operator-config.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
-	a := &asset{bytes: bytes, info: info}
-	return a, nil
-}
-
 var _v3110OpenshiftSvcatApiserverRoleExtensionApiserverAuthReaderYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -860,7 +835,6 @@ var _bindata = map[string]func() (*asset, error){
 	"v3.11.0/openshift-svcat-apiserver/crb-serviceclass-viewer-binding.yaml":             v3110OpenshiftSvcatApiserverCrbServiceclassViewerBindingYaml,
 	"v3.11.0/openshift-svcat-apiserver/ds.yaml":                                          v3110OpenshiftSvcatApiserverDsYaml,
 	"v3.11.0/openshift-svcat-apiserver/ns.yaml":                                          v3110OpenshiftSvcatApiserverNsYaml,
-	"v3.11.0/openshift-svcat-apiserver/operator-config.yaml":                             v3110OpenshiftSvcatApiserverOperatorConfigYaml,
 	"v3.11.0/openshift-svcat-apiserver/role-extension-apiserver-auth-reader.yaml":        v3110OpenshiftSvcatApiserverRoleExtensionApiserverAuthReaderYaml,
 	"v3.11.0/openshift-svcat-apiserver/rolebinding-extension-apiserver-auth-reader.yaml": v3110OpenshiftSvcatApiserverRolebindingExtensionApiserverAuthReaderYaml,
 	"v3.11.0/openshift-svcat-apiserver/sa.yaml":                                          v3110OpenshiftSvcatApiserverSaYaml,
@@ -923,9 +897,8 @@ var _bintree = &bintree{nil, map[string]*bintree{
 			"crb-readiness-binding.yaml":           {v3110OpenshiftSvcatApiserverCrbReadinessBindingYaml, map[string]*bintree{}},
 			"crb-sar-creator-binding.yaml":         {v3110OpenshiftSvcatApiserverCrbSarCreatorBindingYaml, map[string]*bintree{}},
 			"crb-serviceclass-viewer-binding.yaml": {v3110OpenshiftSvcatApiserverCrbServiceclassViewerBindingYaml, map[string]*bintree{}},
-			"ds.yaml":                                          {v3110OpenshiftSvcatApiserverDsYaml, map[string]*bintree{}},
-			"ns.yaml":                                          {v3110OpenshiftSvcatApiserverNsYaml, map[string]*bintree{}},
-			"operator-config.yaml":                             {v3110OpenshiftSvcatApiserverOperatorConfigYaml, map[string]*bintree{}},
+			"ds.yaml": {v3110OpenshiftSvcatApiserverDsYaml, map[string]*bintree{}},
+			"ns.yaml": {v3110OpenshiftSvcatApiserverNsYaml, map[string]*bintree{}},
 			"role-extension-apiserver-auth-reader.yaml":        {v3110OpenshiftSvcatApiserverRoleExtensionApiserverAuthReaderYaml, map[string]*bintree{}},
 			"rolebinding-extension-apiserver-auth-reader.yaml": {v3110OpenshiftSvcatApiserverRolebindingExtensionApiserverAuthReaderYaml, map[string]*bintree{}},
 			"sa.yaml":  {v3110OpenshiftSvcatApiserverSaYaml, map[string]*bintree{}},


### PR DESCRIPTION
Don't use the EnsureOperatorConfigExists helper to create operator resource, instead tag the resource to be managed by the CVO