### PR TITLE
switch etcd to openshift-etcd

### DIFF
--- a/bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
@@ -30,7 +30,7 @@ spec:
         - --secure-port
         - "6443"
         - --etcd-servers
-        - "https://etcd.kube-system.svc.cluster.local:2379"
+        - "https://etcd.openshift-etcd.svc.cluster.local:2379"
         - --etcd-cafile
         - "/var/run/configmaps/etcd-serving-ca/ca-bundle.crt"
         - --etcd-certfile

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -532,7 +532,7 @@ spec:
         - --secure-port
         - "6443"
         - --etcd-servers
-        - "https://etcd.kube-system.svc.cluster.local:2379"
+        - "https://etcd.openshift-etcd.svc.cluster.local:2379"
         - --etcd-cafile
         - "/var/run/configmaps/etcd-serving-ca/ca-bundle.crt"
         - --etcd-certfile
@@ -615,7 +615,8 @@ spec:
         secret:
           secretName: etcd-client
       tolerations:
-      - operator: Exists`)
+      - operator: Exists
+`)
 
 func v3110OpenshiftSvcatApiserverDsYamlBytes() ([]byte, error) {
 	return _v3110OpenshiftSvcatApiserverDsYaml, nil


### PR DESCRIPTION
Exploratory pull demonstrating how etcd could be moved to another namespace.

Waiting on https://github.com/openshift/machine-config-operator/pull/648 .  This will need to merge right after.

/hold