### PR TITLE
Bug 1710569 - set prefix to /servicecatalog

### DIFF
--- a/bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
+++ b/bindata/v3.11.0/openshift-svcat-apiserver/ds.yaml
@@ -37,6 +37,8 @@ spec:
         - "/var/run/secrets/etcd-client/tls.crt"
         - --etcd-keyfile
         - "/var/run/secrets/etcd-client/tls.key"
+        - --etcd-prefix
+        - "/servicecatalog"
         - --cors-allowed-origins
         - "localhost"
         - --enable-admission-plugins

--- a/pkg/operator/v311_00_assets/bindata.go
+++ b/pkg/operator/v311_00_assets/bindata.go
@@ -538,6 +538,8 @@ spec:
         - "/var/run/secrets/etcd-client/tls.crt"
         - --etcd-keyfile
         - "/var/run/secrets/etcd-client/tls.key"
+        - --etcd-prefix
+        - "/servicecatalog"
         - --cors-allowed-origins
         - "localhost"
         - --enable-admission-plugins


### PR DESCRIPTION
Change the storage prefix from the default of `/registry/` to `/servicecatalog.k8s.io`.