### PR TITLE
Update Dockerfile.rhel7 to go 1.12

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,4 @@
-FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.11 AS builder
+FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-svcat-apiserver-operator
 COPY . .
 RUN go build ./cmd/cluster-svcat-apiserver-operator


### PR DESCRIPTION
Other files were updated for go 1.12 in commit c005ab3b263ff39196479c2c746938ebe7ef40b8 but Dockerfile.rhel7 was missed, causing the downstream build to fail: 
`vendor/github.com/openshift/library-go/pkg/crypto/crypto.go:39:18: undefined: tls.VersionTLS13`