### PR TITLE
manifests/00_namespace.yaml: add monitoring label

### DIFF
--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -5,3 +5,5 @@ metadata:
   name: openshift-service-catalog-apiserver-operator
   annotations:
     openshift.io/node-selector: ""
+  labels:
+    openshift.io/cluster-monitoring: "true"


### PR DESCRIPTION
Currently, service monitors in this namespace are not picked up by cluster monitoring as the namespace does not have the correct label set.

/cc @LiliC @paulfantom