### PR TITLE
add gauge showing when svcat is enabled

### DIFF
--- a/manifests/0000_90_cluster-svcat-apiserver-operator_02-operator-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-svcat-apiserver-operator_02-operator-servicemonitor.yaml
@@ -40,7 +40,6 @@ spec:
             summary: Indicates whether Service Catalog is enabled
           expr: |
             service_catalog_apiserver_enabled > 0
-          for: 12h
           labels:
             severity: warning
 

--- a/manifests/0000_90_cluster-svcat-apiserver-operator_02-operator-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-svcat-apiserver-operator_02-operator-servicemonitor.yaml
@@ -37,7 +37,7 @@ spec:
       rules:
         - alert: ServiceCatalogAPIServerEnabled
           annotations:
-            summary: Indicates whether Service Catalog is enabled
+            summary: Indicates whether Service Catalog API Server is enabled
           expr: |
             service_catalog_apiserver_enabled > 0
           labels:

--- a/manifests/0000_90_cluster-svcat-apiserver-operator_02-operator-servicemonitor.yaml
+++ b/manifests/0000_90_cluster-svcat-apiserver-operator_02-operator-servicemonitor.yaml
@@ -25,3 +25,22 @@ spec:
   selector:
     matchLabels:
       app: openshift-service-catalog-apiserver-operator
+---
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: openshift-service-catalog-apiserver-operator
+  namespace: openshift-service-catalog-apiserver-operator
+spec:
+  groups:
+    - name: svcat-apiserver-enabled
+      rules:
+        - alert: ServiceCatalogAPIServerEnabled
+          annotations:
+            summary: Indicates whether Service Catalog is enabled
+          expr: |
+            service_catalog_apiserver_enabled > 0
+          for: 12h
+          labels:
+            severity: warning
+

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -1,0 +1,54 @@
+package metrics
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"k8s.io/klog"
+)
+
+var (
+	buildInfo = prometheus.NewGaugeVec(
+		prometheus.GaugeOpts{
+			Name: "openshift_cluster_openshift_apiserver_operator_build_info",
+			Help: "A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift API Server was built.",
+		},
+		[]string{"major", "minor", "gitCommit", "gitVersion"},
+	)
+
+	apiserverEnabled = prometheus.NewGauge(
+		prometheus.GaugeOpts{
+			Name: "service_catalog_apiserver_enabled",
+			Help: "Indicates whether Service Catalog apiserver is enabled",
+		})
+)
+
+func init() {
+	// do the MustRegister here
+	prometheus.MustRegister(buildInfo)
+	prometheus.MustRegister(apiserverEnabled)
+}
+
+// We will never want to panic our operator because of metric saving.
+// Therefore, we will recover our panics here and error log them
+// for later diagnosis but will never fail the operator.
+func recoverMetricPanic() {
+	if r := recover(); r != nil {
+		klog.Errorf("Recovering from metric function - %v", r)
+	}
+}
+
+func RegisterVersion(major, minor, gitCommit, gitVersion string) {
+	defer recoverMetricPanic()
+	buildInfo.WithLabelValues(major, minor, gitCommit, gitVersion).Set(1)
+}
+
+// APIServerEnabled - Indicates Service Catalog APIServer has been enabled
+func APIServerEnabled() {
+	defer recoverMetricPanic()
+	apiserverEnabled.Inc()
+}
+
+// APIServerDisabled - Indicates Service Catalog APIServer has been disabled
+func APIServerDisabled() {
+	defer recoverMetricPanic()
+	apiserverEnabled.Dec()
+}

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -8,7 +8,7 @@ import (
 var (
 	buildInfo = prometheus.NewGaugeVec(
 		prometheus.GaugeOpts{
-			Name: "openshift_cluster_openshift_apiserver_operator_build_info",
+			Name: "openshift_cluster_svcat_apiserver_operator_build_info",
 			Help: "A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift API Server was built.",
 		},
 		[]string{"major", "minor", "gitCommit", "gitVersion"},
@@ -44,11 +44,11 @@ func RegisterVersion(major, minor, gitCommit, gitVersion string) {
 // APIServerEnabled - Indicates Service Catalog APIServer has been enabled
 func APIServerEnabled() {
 	defer recoverMetricPanic()
-	apiserverEnabled.Inc()
+	apiserverEnabled.Set(1.0)
 }
 
 // APIServerDisabled - Indicates Service Catalog APIServer has been disabled
 func APIServerDisabled() {
 	defer recoverMetricPanic()
-	apiserverEnabled.Dec()
+	apiserverEnabled.Set(0.0)
 }

--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/metrics"
 	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/operator/operatorclient"
 
 	"k8s.io/klog"
@@ -144,6 +145,7 @@ func (c ServiceCatalogAPIServerOperator) sync() error {
 				return err
 			}
 		}
+		metrics.APIServerDisabled()
 		return nil
 	case operatorsv1.Removed:
 		// delete the owner references from the service bindings
@@ -203,12 +205,14 @@ func (c ServiceCatalogAPIServerOperator) sync() error {
 				return err
 			}
 		}
+		metrics.APIServerDisabled()
 		return nil
 	default:
 		c.eventRecorder.Warningf("ManagementStateUnknown", "Unrecognized operator management state %q", operatorConfig.Spec.ManagementState)
 		return nil
 	}
 
+	metrics.APIServerEnabled()
 	forceRequeue, err := syncServiceCatalogAPIServer_v311_00_to_latest(c, operatorConfig)
 	if forceRequeue && err != nil {
 		c.queue.AddRateLimited(workQueueKey)

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,8 +1,7 @@
 package version
 
 import (
-	"github.com/prometheus/client_golang/prometheus"
-
+	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/metrics"
 	"k8s.io/apimachinery/pkg/version"
 )
 
@@ -34,14 +33,5 @@ func Get() version.Info {
 }
 
 func init() {
-	buildInfo := prometheus.NewGaugeVec(
-		prometheus.GaugeOpts{
-			Name: "openshift_cluster_openshift_apiserver_operator_build_info",
-			Help: "A metric with a constant '1' value labeled by major, minor, git commit & git version from which OpenShift API Server was built.",
-		},
-		[]string{"major", "minor", "gitCommit", "gitVersion"},
-	)
-	buildInfo.WithLabelValues(majorFromGit, minorFromGit, commitFromGit, versionFromGit).Set(1)
-
-	prometheus.MustRegister(buildInfo)
+	metrics.RegisterVersion(majorFromGit, minorFromGit, commitFromGit, versionFromGit)
 }


### PR DESCRIPTION
This gauge will be used in an alert to notice when the service catalog's apiserver is running.