### PR TITLE
Add the version option do display git commit info

### DIFF
--- a/cmd/cluster-svcat-apiserver-operator/main.go
+++ b/cmd/cluster-svcat-apiserver-operator/main.go
@@ -10,11 +10,13 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
+	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/cmd/operator"
+	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/version"
 	utilflag "k8s.io/component-base/cli/flag"
 	"k8s.io/component-base/logs"
-
-	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/cmd/operator"
 )
+
+var versionFlag = goflag.Bool("version", false, "displays source commit info.")
 
 func main() {
 	rand.Seed(time.Now().UTC().UnixNano())
@@ -25,11 +27,19 @@ func main() {
 	logs.InitLogs()
 	defer logs.FlushLogs()
 
+	goflag.Parse()
+	if *versionFlag {
+		fmt.Print(version.Commit())
+		// Exit immediately
+		os.Exit(0)
+	}
+
 	command := NewSSCSCommand()
 	if err := command.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		os.Exit(1)
 	}
+
 }
 
 func NewSSCSCommand() *cobra.Command {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,6 +1,7 @@
 package version
 
 import (
+	"fmt"
 	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/metrics"
 	"k8s.io/apimachinery/pkg/version"
 )
@@ -34,4 +35,9 @@ func Get() version.Info {
 
 func init() {
 	metrics.RegisterVersion(majorFromGit, minorFromGit, commitFromGit, versionFromGit)
+}
+
+// Commit returns a pretty string concatenation of GitCommit
+func Commit() string {
+	return fmt.Sprintf("cluster-svcat-apiserver-operator source git commit: %s\n", commitFromGit)
 }


### PR DESCRIPTION
Add the --version flag to display the source commit info. The users will get the exact version info easily.
```console
mac:cluster-svcat-apiserver-operator jianzhang$ ./cluster-svcat-apiserver-operator --version
cluster-svcat-apiserver-operator source git commit: 5bc6dc18
```

```console
mac:cluster-svcat-apiserver-operator jianzhang$ make build
fatal: No names found, cannot describe anything.
go build -ldflags "-s -w -X github.com/openshift/cluster-svcat-apiserver-operator/pkg/version.versionFromGit="v0.0.0-unknown" -X github.com/openshift/cluster-svcat-apiserver-operator/pkg/version.commitFromGit="5bc6dc18" -X github.com/openshift/cluster-svcat-apiserver-operator/pkg/version.gitTreeState="clean" -X github.com/openshift/cluster-svcat-apiserver-operator/pkg/version.buildDate="2019-11-02T10:15:53Z" " github.com/openshift/cluster-svcat-apiserver-operator/cmd/cluster-svcat-apiserver-operator

mac:cluster-svcat-apiserver-operator jianzhang$ ./cluster-svcat-apiserver-operator --help
Usage of ./cluster-svcat-apiserver-operator:
  -alsologtostderr
    	log to standard error as well as files
  -log_backtrace_at value
    	when logging hits line file:N, emit a stack trace
  -log_dir string
    	If non-empty, write log files in this directory
  -log_file string
    	If non-empty, use this log file
  -logtostderr
    	log to standard error instead of files (default true)
  -skip_headers
    	If true, avoid header prefixes in the log messages
  -stderrthreshold value
    	logs at or above this threshold go to stderr (default 2)
  -v value
    	number for the log level verbosity
  -version
    	displays source commit info.
  -vmodule value
    	comma-separated list of pattern=N settings for file-filtered logging
```