### PR TITLE
Bug 1791001: use make build so ldflags are passed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM registry.svc.ci.openshift.org/openshift/release:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-svcat-apiserver-operator
 COPY . .
-RUN GODEBUG=tls13=1 go build ./cmd/cluster-svcat-apiserver-operator
+RUN make build --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-svcat-apiserver-operator/cluster-svcat-apiserver-operator /usr/bin/

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,7 +1,7 @@
 FROM registry.svc.ci.openshift.org/ocp/builder:golang-1.12 AS builder
 WORKDIR /go/src/github.com/openshift/cluster-svcat-apiserver-operator
 COPY . .
-RUN go build ./cmd/cluster-svcat-apiserver-operator
+RUN make build --warn-undefined-variables
 
 FROM registry.svc.ci.openshift.org/ocp/4.0:base
 COPY --from=builder /go/src/github.com/openshift/cluster-svcat-apiserver-operator/cluster-svcat-apiserver-operator /usr/bin/


### PR DESCRIPTION
Fix builds so that the gitcommit information is passed down properly. This will fix the build_info metric.