### PR TITLE
Bug 1831019: Upgradeable = False, link to OpenShift docs

### DIFF
--- a/pkg/operator/workloadcontroller/workload_controller.go
+++ b/pkg/operator/workloadcontroller/workload_controller.go
@@ -123,7 +123,7 @@ func (c ServiceCatalogAPIServerOperator) sync() error {
 			Type:    operatorsv1.OperatorStatusTypeUpgradeable,
 			Status:  operatorsv1.ConditionFalse,
 			Reason:  "Managed",
-			Message: "the apiserver is in a managed state, upgrades are not possible.",
+			Message: "The Service Catalog is deprecated, upgrades are not possible. Please visit this link for further details: https://docs.openshift.com/container-platform/4.4/applications/service_brokers/installing-service-catalog.html",
 		})
 	case operatorsv1.Unmanaged:
 		originalOperatorConfig := operatorConfig.DeepCopy()
@@ -131,25 +131,25 @@ func (c ServiceCatalogAPIServerOperator) sync() error {
 			Type:    operatorsv1.OperatorStatusTypeAvailable,
 			Status:  operatorsv1.ConditionUnknown,
 			Reason:  "Unmanaged",
-			Message: "the apiserver is in an unmanaged state, therefore its availability is unknown.",
+			Message: "The apiserver is in an unmanaged state, therefore its availability is unknown.",
 		})
 		v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorsv1.OperatorCondition{
 			Type:    operatorsv1.OperatorStatusTypeProgressing,
 			Status:  operatorsv1.ConditionFalse,
 			Reason:  "Unmanaged",
-			Message: "the apiserver is in an unmanaged state, therefore no changes are being applied.",
+			Message: "The apiserver is in an unmanaged state, therefore no changes are being applied.",
 		})
 		v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorsv1.OperatorCondition{
 			Type:    operatorsv1.OperatorStatusTypeDegraded,
 			Status:  operatorsv1.ConditionFalse,
 			Reason:  "Unmanaged",
-			Message: "the apiserver is in an unmanaged state, therefore no operator actions are degraded.",
+			Message: "The apiserver is in an unmanaged state, therefore no operator actions are degraded.",
 		})
 		v1helpers.SetOperatorCondition(&operatorConfig.Status.Conditions, operatorsv1.OperatorCondition{
 			Type:    operatorsv1.OperatorStatusTypeUpgradeable,
 			Status:  operatorsv1.ConditionTrue,
 			Reason:  "Unmanaged",
-			Message: "the apiserver is in an unmanaged state, upgrades are possible.",
+			Message: "The apiserver is in an unmanaged state, upgrades are possible.",
 		})
 
 		if !equality.Semantic.DeepEqual(operatorConfig.Status, originalOperatorConfig.Status) {

--- a/pkg/operator/workloadcontroller/workload_controller_test.go
+++ b/pkg/operator/workloadcontroller/workload_controller_test.go
@@ -1,0 +1,149 @@
+package workloadcontroller
+
+import (
+	"strings"
+	"testing"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+	operatorfake "github.com/openshift/client-go/operator/clientset/versioned/fake"
+	"github.com/openshift/cluster-svcat-apiserver-operator/pkg/operator/operatorclient"
+	"github.com/openshift/library-go/pkg/operator/events"
+	"github.com/openshift/library-go/pkg/operator/status"
+	operatorv1helpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes/fake"
+	kubeaggregatorfake "k8s.io/kube-aggregator/pkg/client/clientset_generated/clientset/fake"
+)
+
+func TestUpgradeable(t *testing.T) {
+
+	testCases := []struct {
+		name            string
+		managementState operatorv1.ManagementState
+		expectedStatus  operatorv1.ConditionStatus
+		expectedMessage string
+		substring       bool
+	}{
+		{
+			name:            "in managed state, upgradeable should be false",
+			managementState: operatorv1.Managed,
+			expectedStatus:  operatorv1.ConditionFalse,
+			substring:       true,
+			expectedMessage: "https://docs.openshift.com/container-platform/4.4/applications/service_brokers/installing-service-catalog.html",
+		},
+		{
+			name:            "in unmanaged state, upgradeable should be true",
+			managementState: operatorv1.Unmanaged,
+			expectedStatus:  operatorv1.ConditionTrue,
+			substring:       true,
+			expectedMessage: "unmanaged state, upgrades are possible",
+		},
+		{
+			name:            "in removed state, upgradeable should be true",
+			managementState: operatorv1.Removed,
+			expectedStatus:  operatorv1.ConditionTrue,
+			substring:       true,
+			expectedMessage: "removed state, upgrades are possible",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// create kube client
+			kubeClient := fake.NewSimpleClientset(
+				&appsv1.DaemonSet{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:       "apiserver",
+						Namespace:  operatorclient.TargetNamespaceName,
+						Generation: 100,
+					},
+					Status: appsv1.DaemonSetStatus{
+						NumberAvailable:    100,
+						ObservedGeneration: 100,
+					},
+				})
+
+			// create operator config
+			operatorConfig := &operatorv1.ServiceCatalogAPIServer{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:       "cluster",
+					Generation: 100,
+				},
+				Spec: operatorv1.ServiceCatalogAPIServerSpec{
+					OperatorSpec: operatorv1.OperatorSpec{
+						ManagementState: tc.managementState,
+					},
+				},
+				Status: operatorv1.ServiceCatalogAPIServerStatus{
+					OperatorStatus: operatorv1.OperatorStatus{
+						ObservedGeneration: 100,
+					},
+				},
+			}
+
+			// create apiserver client and required clients
+			apiServiceOperatorClient := operatorfake.NewSimpleClientset(operatorConfig)
+			kubeAggregatorClient := kubeaggregatorfake.NewSimpleClientset()
+
+			// create dynamic client
+			dynamicScheme := runtime.NewScheme()
+			dynamicScheme.AddKnownTypeWithName(schema.GroupVersionKind{
+				Group:   "monitoring.coreos.com",
+				Version: "v1",
+				Kind:    "ServiceMonitor"},
+				&unstructured.Unstructured{})
+			dynamicClient := dynamicfake.NewSimpleDynamicClient(dynamicScheme)
+
+			// Finally create the operator we need to test
+			operator := ServiceCatalogAPIServerOperator{
+				kubeClient:              kubeClient,
+				eventRecorder:           events.NewInMemoryRecorder(""),
+				operatorConfigClient:    apiServiceOperatorClient.OperatorV1(),
+				dynamicClient:           dynamicClient,
+				apiregistrationv1Client: kubeAggregatorClient.ApiregistrationV1(),
+				versionRecorder:         status.NewVersionGetter(),
+			}
+
+			// Test the sync method
+			err := operator.sync()
+			if err != nil {
+				t.Fatal("Unexpected error running sync")
+			}
+
+			// verify results
+			result, err := apiServiceOperatorClient.OperatorV1().
+				ServiceCatalogAPIServers().Get("cluster", metav1.GetOptions{})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			condition := operatorv1helpers.FindOperatorCondition(
+				result.Status.Conditions, operatorv1.OperatorStatusTypeUpgradeable)
+			if condition == nil {
+				t.Fatalf("No %v condition found.", operatorv1.OperatorStatusTypeUpgradeable)
+			}
+
+			// verify the status
+			if condition.Status != tc.expectedStatus {
+				t.Errorf("expected %v but received %v", tc.expectedStatus, condition.Status)
+			}
+
+			// verify the status messages
+			if tc.substring {
+				if !strings.Contains(condition.Message, tc.expectedMessage) {
+					t.Fatalf("expected to find %v in the message: %v", tc.expectedMessage, condition.Message)
+				}
+			} else {
+				if condition.Message != tc.expectedMessage {
+					t.Fatalf("expected %v to match message:%v", tc.expectedMessage, condition.Message)
+				}
+			}
+		})
+	}
+}

--- a/vendor/k8s.io/client-go/dynamic/fake/simple.go
+++ b/vendor/k8s.io/client-go/dynamic/fake/simple.go
@@ -1,0 +1,370 @@
+/*
+Copyright 2018 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fake
+
+import (
+	"strings"
+
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/dynamic"
+	"k8s.io/client-go/testing"
+)
+
+func NewSimpleDynamicClient(scheme *runtime.Scheme, objects ...runtime.Object) *FakeDynamicClient {
+	// In order to use List with this client, you have to have the v1.List registered in your scheme. Neat thing though
+	// it does NOT have to be the *same* list
+	scheme.AddKnownTypeWithName(schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "List"}, &unstructured.UnstructuredList{})
+
+	codecs := serializer.NewCodecFactory(scheme)
+	o := testing.NewObjectTracker(scheme, codecs.UniversalDecoder())
+	for _, obj := range objects {
+		if err := o.Add(obj); err != nil {
+			panic(err)
+		}
+	}
+
+	cs := &FakeDynamicClient{scheme: scheme}
+	cs.AddReactor("*", "*", testing.ObjectReaction(o))
+	cs.AddWatchReactor("*", func(action testing.Action) (handled bool, ret watch.Interface, err error) {
+		gvr := action.GetResource()
+		ns := action.GetNamespace()
+		watch, err := o.Watch(gvr, ns)
+		if err != nil {
+			return false, nil, err
+		}
+		return true, watch, nil
+	})
+
+	return cs
+}
+
+// Clientset implements clientset.Interface. Meant to be embedded into a
+// struct to get a default implementation. This makes faking out just the method
+// you want to test easier.
+type FakeDynamicClient struct {
+	testing.Fake
+	scheme *runtime.Scheme
+}
+
+type dynamicResourceClient struct {
+	client    *FakeDynamicClient
+	namespace string
+	resource  schema.GroupVersionResource
+}
+
+var _ dynamic.Interface = &FakeDynamicClient{}
+
+func (c *FakeDynamicClient) Resource(resource schema.GroupVersionResource) dynamic.NamespaceableResourceInterface {
+	return &dynamicResourceClient{client: c, resource: resource}
+}
+
+func (c *dynamicResourceClient) Namespace(ns string) dynamic.ResourceInterface {
+	ret := *c
+	ret.namespace = ns
+	return &ret
+}
+
+func (c *dynamicResourceClient) Create(obj *unstructured.Unstructured, opts metav1.CreateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		accessor, err := meta.Accessor(obj)
+		if err != nil {
+			return nil, err
+		}
+		name := accessor.GetName()
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewCreateSubresourceAction(c.resource, name, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Update(obj *unstructured.Unstructured, opts metav1.UpdateOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateAction(c.resource, obj), obj)
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateAction(c.resource, c.namespace, obj), obj)
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) UpdateStatus(obj *unstructured.Unstructured, opts metav1.UpdateOptions) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootUpdateSubresourceAction(c.resource, "status", obj), obj)
+
+	case len(c.namespace) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewUpdateSubresourceAction(c.resource, "status", c.namespace, obj), obj)
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) Delete(name string, opts *metav1.DeleteOptions, subresources ...string) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteAction(c.resource, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewRootDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		_, err = c.client.Fake.
+			Invokes(testing.NewDeleteSubresourceAction(c.resource, strings.Join(subresources, "/"), c.namespace, name), &metav1.Status{Status: "dynamic delete fail"})
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) DeleteCollection(opts *metav1.DeleteOptions, listOptions metav1.ListOptions) error {
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		action := testing.NewRootDeleteCollectionAction(c.resource, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	case len(c.namespace) > 0:
+		action := testing.NewDeleteCollectionAction(c.resource, c.namespace, listOptions)
+		_, err = c.client.Fake.Invokes(action, &metav1.Status{Status: "dynamic deletecollection fail"})
+
+	}
+
+	return err
+}
+
+func (c *dynamicResourceClient) Get(name string, opts metav1.GetOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetAction(c.resource, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootGetSubresourceAction(c.resource, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetAction(c.resource, c.namespace, name), &metav1.Status{Status: "dynamic get fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewGetSubresourceAction(c.resource, c.namespace, strings.Join(subresources, "/"), name), &metav1.Status{Status: "dynamic get fail"})
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}
+
+func (c *dynamicResourceClient) List(opts metav1.ListOptions) (*unstructured.UnstructuredList, error) {
+	var obj runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewRootListAction(c.resource, schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "" /*List is appended by the tracker automatically*/}, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	case len(c.namespace) > 0:
+		obj, err = c.client.Fake.
+			Invokes(testing.NewListAction(c.resource, schema.GroupVersionKind{Group: "fake-dynamic-client-group", Version: "v1", Kind: "" /*List is appended by the tracker automatically*/}, c.namespace, opts), &metav1.Status{Status: "dynamic list fail"})
+
+	}
+
+	if obj == nil {
+		return nil, err
+	}
+
+	label, _, _ := testing.ExtractFromListOptions(opts)
+	if label == nil {
+		label = labels.Everything()
+	}
+
+	retUnstructured := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(obj, retUnstructured, nil); err != nil {
+		return nil, err
+	}
+	entireList, err := retUnstructured.ToList()
+	if err != nil {
+		return nil, err
+	}
+
+	list := &unstructured.UnstructuredList{}
+	list.SetResourceVersion(entireList.GetResourceVersion())
+	for i := range entireList.Items {
+		item := &entireList.Items[i]
+		metadata, err := meta.Accessor(item)
+		if err != nil {
+			return nil, err
+		}
+		if label.Matches(labels.Set(metadata.GetLabels())) {
+			list.Items = append(list.Items, *item)
+		}
+	}
+	return list, nil
+}
+
+func (c *dynamicResourceClient) Watch(opts metav1.ListOptions) (watch.Interface, error) {
+	switch {
+	case len(c.namespace) == 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewRootWatchAction(c.resource, opts))
+
+	case len(c.namespace) > 0:
+		return c.client.Fake.
+			InvokesWatch(testing.NewWatchAction(c.resource, c.namespace, opts))
+
+	}
+
+	panic("math broke")
+}
+
+// TODO: opts are currently ignored.
+func (c *dynamicResourceClient) Patch(name string, pt types.PatchType, data []byte, opts metav1.PatchOptions, subresources ...string) (*unstructured.Unstructured, error) {
+	var uncastRet runtime.Object
+	var err error
+	switch {
+	case len(c.namespace) == 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchAction(c.resource, name, pt, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) == 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewRootPatchSubresourceAction(c.resource, name, pt, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) == 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchAction(c.resource, c.namespace, name, pt, data), &metav1.Status{Status: "dynamic patch fail"})
+
+	case len(c.namespace) > 0 && len(subresources) > 0:
+		uncastRet, err = c.client.Fake.
+			Invokes(testing.NewPatchSubresourceAction(c.resource, c.namespace, name, pt, data, subresources...), &metav1.Status{Status: "dynamic patch fail"})
+
+	}
+
+	if err != nil {
+		return nil, err
+	}
+	if uncastRet == nil {
+		return nil, err
+	}
+
+	ret := &unstructured.Unstructured{}
+	if err := c.client.scheme.Convert(uncastRet, ret, nil); err != nil {
+		return nil, err
+	}
+	return ret, err
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -548,6 +548,7 @@ k8s.io/apiserver/plugin/pkg/authorizer/webhook
 k8s.io/client-go/discovery
 k8s.io/client-go/discovery/fake
 k8s.io/client-go/dynamic
+k8s.io/client-go/dynamic/fake
 k8s.io/client-go/informers
 k8s.io/client-go/informers/admissionregistration
 k8s.io/client-go/informers/admissionregistration/v1


### PR DESCRIPTION
The service catalog is deprecated. In OpenShift 4.4, we will block
upgrades to 4.5 or later by setting the Upgradeable field to False.
This PR updates the message to point to the documentation that states
that.